### PR TITLE
🚨 Add toml linter + fix cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v1
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Setup rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,6 +132,17 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -126,6 +126,26 @@ jobs:
         run: |
           cargo make lint-rust-format
 
+  lint-toml:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          default: true
+          override: true
+
+      - name: Install cargo make
+        uses: davidB/rust-cargo-make@v1
+
+      - name: Lint toml
+        run: |
+          cargo make lint-toml
+
   lint-branch-name:
     runs-on: ubuntu-20.04
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v1
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Setup rust
         uses: actions-rs/toolchain@v1

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+include = ["**/*.toml"]
+
+[formatting]
+align_entries = false
+reorder_keys = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "template-rust"
-version = "0.1.0"
-edition = "2021"
 authors = ["OKP4.com"]
 description = "A template project for Rust."
 documentation = "https://github.com/okp4/template-rust/blob/master/README.md"
+edition = "2021"
 homepage = "https://github.com/okp4/template-rust"
-repository = "https://github.com/okp4/template-rust"
-readme = "README.md"
 license-file = "LICENSE"
+name = "template-rust"
+readme = "README.md"
+repository = "https://github.com/okp4/template-rust"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
-authors = ["OKP4.com"]
+authors = ["OKP4"]
 description = "A template project for Rust."
-documentation = "https://github.com/okp4/template-rust/blob/master/README.md"
 edition = "2021"
-homepage = "https://github.com/okp4/template-rust"
 license-file = "LICENSE"
 name = "template-rust"
 readme = "README.md"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,19 +28,19 @@ description = "Check lint of all sources files."
 install_crate = { rustup_component_name = "clippy" }
 
 [tasks.lint-toml]
-args = ["lint", "*.toml"]
+install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 command = "taplo"
 description = "Check lint of all toml files."
-install_crate = { crate_name = "taplo-cli" }
+args = ["lint", "*.toml"]
 
 [tasks.format-toml]
 args = ["lint", "*.toml"]
 command = "taplo"
 description = "Format toml file"
-install_crate = { crate_name = "taplo-cli" }
+install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
 [tasks.lint]
-dependencies = ["lint-rust-format", "lint-rust"]
+dependencies = ["lint-rust-format", "lint-rust", "lint-toml"]
 
 [tasks.format]
 dependencies = ["format-rust", "format-toml"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,13 +28,13 @@ description = "Check lint of all sources files."
 install_crate = { rustup_component_name = "clippy" }
 
 [tasks.lint-toml]
-install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
+args = ["lint"]
 command = "taplo"
 description = "Check lint of all toml files."
-args = ["lint", "*.toml"]
+install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
 [tasks.format-toml]
-args = ["lint", "*.toml"]
+args = ["fmt"]
 command = "taplo"
 description = "Format toml file"
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
@@ -54,22 +54,22 @@ args = ["build", "--release", "--locked"]
 command = "cargo"
 
 [tasks.build-coverage]
+args = ["build"]
+command = "cargo"
 description = "Compile the source code and create testable artifacts."
 env = { RUSTFLAGS = "-Cinstrument-coverage" }
-command = "cargo"
-args = ["build"]
 
 [tasks.test]
 args = ["test", "--tests", "--workspace", "--locked", "--all-features"]
 command = "cargo"
-description = "Run all unit tests."
 dependencies = ["build-coverage"]
+description = "Run all unit tests."
 env = { LLVM_PROFILE_FILE = "default.profraw", RUST_BACKTRACE = 1 }
 install_crate = { rustup_component_name = "llvm-tools-preview" }
 
 [tasks.test-coverage]
-install_crate = { crate_name = "grcov" }
 dependencies = ["test"]
+install_crate = { crate_name = "grcov" }
 script = '''
 grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "*cargo*" -o coverage.lcov
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,26 +1,49 @@
-[tasks.format]
+[tasks.format-rust]
 args = ["fmt"]
 command = "cargo"
-description = "Format sources files."
-install_crate = {rustup_component_name = "rustfmt"}
+description = "Format rust sources files."
+install_crate = { rustup_component_name = "rustfmt" }
 
 [tasks.lint-rust-format]
 args = ["fmt", "--all", "--", "--check"]
 command = "cargo"
 description = "Check format of sources files."
-install_crate = {rustup_component_name = "rustfmt"}
+install_crate = { rustup_component_name = "rustfmt" }
 
 [tasks.lint-rust]
-args = ["clippy", "--workspace", "--locked", "--all-targets", "--all-features", "--", "-D", "clippy::all", "-D", "warnings"]
+args = [
+  "clippy",
+  "--workspace",
+  "--locked",
+  "--all-targets",
+  "--all-features",
+  "--",
+  "-D",
+  "clippy::all",
+  "-D",
+  "warnings",
+]
 command = "cargo"
 description = "Check lint of all sources files."
-install_crate = {rustup_component_name = "clippy"}
+install_crate = { rustup_component_name = "clippy" }
+
+[tasks.lint-toml]
+args = ["lint", "*.toml"]
+command = "taplo"
+description = "Check lint of all toml files."
+install_crate = { crate_name = "taplo-cli" }
+
+[tasks.format-toml]
+args = ["lint", "*.toml"]
+command = "taplo"
+description = "Format toml file"
+install_crate = { crate_name = "taplo-cli" }
 
 [tasks.lint]
-dependencies = [
-  "lint-rust-format",
-  "lint-rust",
-]
+dependencies = ["lint-rust-format", "lint-rust"]
+
+[tasks.format]
+dependencies = ["format-rust", "format-toml"]
 
 [tasks.clean]
 args = ["clean"]
@@ -50,7 +73,3 @@ dependencies = ["test"]
 script = '''
 grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "*cargo*" -o coverage.lcov
 '''
-
-
-
-


### PR DESCRIPTION
#### 🚨 Add toml linter

- Split `cargo make format` command 
  - `cargo make format-rust`
  - `cargo make format-toml`
- Add `cargo make lint-tool` command 
  - This command is used as dependency of `cargo make lint` 
- Add GitHub action to exec [taplo](https://github.com/tamasfe/taplo) and lint toml files. A GitHub action already exist (https://github.com/yisonPylkita/gh-action-toml-linter) but the binary is not up to date. So, we need to install Taplo by using cargo, but is't take time. To fix this I've add the rust cache action but is not working. When use the classic cache action with custom key it's working. 
- Remove rustcache action replaced by classic cache GitHub action on all rust action (test, lint, build) 