### PR TITLE
🤖 Configure dependabot for cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,14 @@ updates:
       interval: "daily"
     reviewers:
       - "maintainers"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    reviewers:
+      - amimart
+      - ccamel
+    assignees:
+      - amimart
+      - ccamel


### PR DESCRIPTION
#### 🤖 Configure dependabot

By following our other repositories, Dependabot has been configured to daily check the cargo dependencies. 