### PR TITLE
CI: Move cargo lint into a cargo make task

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,15 +63,14 @@ jobs:
           default: true
           override: true
 
-      - name: Install cargo-toml-lint
-        if: steps.changed-rust-cargo.outputs.any_changed == 'true'
-        run: |
-          cargo install --force cargo-toml-lint
+      - name: Install cargo make
+        if: steps.changed-rust-files.outputs.any_changed == 'true'
+        uses: davidB/rust-cargo-make@v1
 
-      - name: Lint toml files
-        if: steps.changed-rust-cargo.outputs.any_changed == 'true'
+      - name: Lint cargo toml
+        if: steps.changed-rust-files.outputs.any_changed == 'true'
         run: |
-          cargo-toml-lint Cargo.toml
+          cargo make lint-cargo-toml
 
   lint-rust:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.lcov
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -33,6 +33,12 @@ command = "taplo"
 description = "Check lint of all toml files."
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
+[tasks.lint-cargo-toml]
+args = ["Cargo.toml"]
+command = "cargo-toml-lint"
+description = "Check lint of cargo toml files."
+install_crate = { crate_name = "cargo-toml-lint", binary = "cargo-toml-lint", test_arg = "--help" }
+
 [tasks.format-toml]
 args = ["fmt"]
 command = "taplo"
@@ -40,7 +46,7 @@ description = "Format toml file"
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
 [tasks.lint]
-dependencies = ["lint-rust-format", "lint-rust", "lint-toml"]
+dependencies = ["lint-rust-format", "lint-rust", "lint-toml", "lint-cargo-toml"]
 
 [tasks.format]
 dependencies = ["format-rust", "format-toml"]


### PR DESCRIPTION
I've simply moved the cargo toml lint into a new cargo make task in order to execute all lints by typing `cargo make lint` command. 

I've also set `fail_ci_if_error` property to false for codecov in order to avoid fail ci on private project.